### PR TITLE
Add a configurable comment message

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,22 @@ npm start
 
 See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance of this app.
 
+## Configuration
+
+You can specify a configuration by adding a file to your repo named
+`.github/mistaken-pull-closer.yml`.  Example:
+```
+# The message to post to the closed PR.
+commentBody: |
+  You are a developer star
+  Who will probably go quite far,
+    But you pushed a commit
+    That seems too unfit,
+  So I am going to close this PR.
+
+  Have a nice day.
+```
+
 ## Searching
 
 To search for pull requests that this bot has closed, use the following search string: [`is:pr commenter:app/mistaken-pull-closer`](https://github.com/search?utf8=✓&q=is%3Apr+commenter%3Aapp%2Fmistaken-pull-closer&type=)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
-const commentBody = `
+const getConfig = require('probot-config')
+
+const defaultConfig = {
+  commentBody: `
 Thanks for your submission.
 
 It appears that you've created a pull request using one of our repository's branches. Since this is
@@ -7,6 +10,7 @@ let us know what you were intending and we can see about reopening it.
 
 Thanks again!
 `
+}
 
 async function addInvalidLabel (context, issue) {
   const params = Object.assign({}, issue, {labels: ['invalid']})
@@ -40,6 +44,8 @@ async function hasPushAccess (context, params) {
 
 module.exports = (robot) => {
   robot.on('pull_request.opened', async context => {
+    const config = await getConfig(
+        context, 'mistaken-pull-closer.yml', defaultConfig)
     const {owner} = context.repo()
     const branchLabel = context.payload.pull_request.head.label
 
@@ -62,7 +68,7 @@ module.exports = (robot) => {
         if (!canPush) {
           robot.log.debug(`PR created from repo branch and user cannot push - closing PR`)
 
-          await comment(context, context.issue({body: commentBody}))
+          await comment(context, context.issue({body: config.commentBody}))
           await addInvalidLabel(context, context.issue())
 
           return close(context, context.issue())

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "npm-run-all test:jest test:standard"
   },
   "dependencies": {
-    "probot": "^0.11.0"
+    "probot": "^0.11.0",
+    "probot-config": "^0.1.0"
   },
   "devDependencies": {
     "eslint-config-probot": ">=0.1.0",


### PR DESCRIPTION
This change uses probot-config to let the deployer customize the body
of the comment that is posted to closed issues.

Additionally, it sets up some tests with jest to test this
functionality.

Dependency: #11 
Issue: #7 