### PR TITLE
Add a configurable filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance 
 You can specify a configuration by adding a file to your repo named
 `.github/mistaken-pull-closer.yml`.  Example:
 ```
+# The JSONPath filter expression used to identify which PRs to close.
+# The data filtered is the pull request data along with other metadata passed in
+# by probot.
+# See http://goessner.net/articles/JsonPath/
+# Default behavior: matches all non-Bot created PRs where the user does not have
+# permission to push to the PR itself.
+filters:
+    - @.pull_request.number == 13
+    - @.pull_request.base.repo.name == "superstitions"
+    - @.pull_request.base.repo.description == "A project opposed to unlucky numbers"
+
 # The message to post to the closed PR.
 commentBody: |
   You are a developer star

--- a/default-config.js
+++ b/default-config.js
@@ -1,4 +1,16 @@
 module.exports = {
+  // Filter explanation:
+  // 1. PR is from a branch in the local repo.
+  // 2. User is not a bot.  If the user is a bot then it was invited to open
+  //    pull requests and isn't thekind of mistake this bot was intended to
+  //    detect.
+  // 3. User does not have push access to the project.  They can't push to
+  //    their own PR and it isn't going to be useful.
+  filters: [
+    '@.pull_request.head.user.login == @.pull_request.base.user.login',
+    '@.pull_request.user.type != "Bot"',
+    '!@.has_push_access'
+  ],
   commentBody: `
 Thanks for your submission.
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "npm-run-all test:jest test:standard"
   },
   "dependencies": {
+    "jsonpath": "^1.0.0",
     "probot": "^7.0.1",
     "probot-config": "^0.2.0"
   },


### PR DESCRIPTION
This change allows users to configure their own filter to specify
mistaken pull requests.  Filters may be specified using JSONPath,
a query language for JSON with multiple implementations.