### PR TITLE
Change the logging level of informational messages to info

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,18 +40,18 @@ module.exports = (app) => {
     const branchLabel = context.payload.pull_request.head.label
     const htmlUrl = context.payload.pull_request.html_url
 
-    app.log.debug(`Inspecting: ${htmlUrl}`)
+    app.log.info(`Inspecting: ${htmlUrl}`)
 
     // If the branch label starts with the owner name, then it is a PR from a branch in the local
     // repo
     if (branchLabel.startsWith(owner)) {
-      app.log.debug(`PR created from branch in the local repo ✅ [1 of 3]`)
+      app.log.info(`PR created from branch in the local repo ✅ [1 of 3]`)
       const user = context.payload.pull_request.user
 
       // If the user is a bot then it was invited to open pull requests and isn't the
       // kind of mistake this bot was intended to detect
       if (user.type !== 'Bot') {
-        app.log.debug(`User creating the PR is not a bot ✅ [2 of 3]`)
+        app.log.info(`User creating the PR is not a bot ✅ [2 of 3]`)
 
         const username = user.login
         const canPush = await hasPushAccess(context, context.repo({username}))
@@ -59,14 +59,14 @@ module.exports = (app) => {
         // If the user creating the PR from a local branch is not a bot and doesn't have push
         // access, then they can't push to their own PR and it isn't going to be useful
         if (!canPush) {
-          app.log.debug(`PR created from repo branch and user cannot push ✅ [3 of 3]`)
+          app.log.info(`PR created from repo branch and user cannot push ✅ [3 of 3]`)
 
           await comment(context, context.issue({body: config.commentBody}))
           if (config.addLabel) {
             await addLabel(context, context.issue(), config.labelName, config.labelColor)
           }
 
-          app.log.debug(`Close PR ${htmlUrl}`)
+          app.log.info(`Close PR ${htmlUrl}`)
           return close(context, context.issue())
         }
       }


### PR DESCRIPTION
The change to Probot v7.x made the default logging level not display the messages I depended on for following the normal operation of the app. Changing the log level to debug made way to much spew. So I'm going to change the log level back to info and bump these messages so they show.