### PR TITLE
:arrow_up: jest@23.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "eslint-config-probot": ">=0.1.0",
-    "jest": "^22.4.4",
+    "jest": "^23.6.0",
     "localtunnel": "^1.8.3",
     "npm-run-all": "^4.1.3",
     "smee-client": "^1.0.2",


### PR DESCRIPTION
When cloning this repo, running `npm install` and then `npm test`, the following error occurs:

```
❯ npm test

> mistaken-pull-closer@2.0.0 test /Users/macklinu/dev/probot/mistaken-pull-closer
> npm-run-all test:jest test:standard


> mistaken-pull-closer@2.0.0 test:jest /Users/macklinu/dev/probot/mistaken-pull-closer
> jest

 FAIL  test/index.test.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.539s
Ran all test suites.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! mistaken-pull-closer@2.0.0 test:jest: `jest`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the mistaken-pull-closer@2.0.0 test:jest script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/macklinu/.npm/_logs/2018-09-13T01_16_33_679Z-debug.log
ERROR: "test:jest" exited with 1.
npm ERR! Test failed.  See above for more details.
```

I believe this is related to https://github.com/facebook/jest/issues/6766, and updating to the latest version of Jest resolves this issue.