### PR TITLE
Upgrade Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "eslint-config-probot": ">=0.1.0",
-    "jest": "^22.4.4",
+    "jest": "^23.6.0",
     "localtunnel": "^1.8.3",
     "npm-run-all": "^4.1.3",
     "smee-client": "^1.0.2",


### PR DESCRIPTION
The previous version of Jest error'd on the most recent version of
JSDom:
https://github.com/facebook/jest/issues/6766

This change simply upgrades Jest so that the tests pass.