### PR TITLE
Stop using deprecated event property

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,6 @@ let github
 function sendPullRequest (payload) {
   return app.receive({
     name: 'pull_request.opened',
-    event: 'pull_request',
     payload: payload
   })
 }


### PR DESCRIPTION
The `event` property in app.receive is deprecated, and probot throws
warnings when our tests run.  This change just removes the relevant line
(since the `name` property sufficiently describes the event).